### PR TITLE
Added launch on URL param

### DIFF
--- a/canvas_launcher.js
+++ b/canvas_launcher.js
@@ -100,6 +100,11 @@ function registerListeners() {
       });
     });
   }
+  // The new code for checking the URL parameter when the page loads:
+  var urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('learnwise') === 'launch') {
+    showChat();
+  }
 }
 
 loadCSS(function() {


### PR DESCRIPTION
Added some gpt generated code to the Listeners that should enable us to launch the full iframe based on a URL parameter "?learnwise=launch". 

Note this is untested. 
Note that this may cause some weirdness that we should check for - like: Will the "Trigger/Launch Button" change state to the X variant automatically or not? GPT says the toggle of the button state is associated with "ShowChat" if that is the case, then all good. 